### PR TITLE
Typo after namespace

### DIFF
--- a/src/Variation/VariantGenerator.php
+++ b/src/Variation/VariantGenerator.php
@@ -1,4 +1,4 @@
-<?php namespace Jiro\Product\Variation;Variation
+<?php namespace Jiro\Product\Variation;
 
 /**
  * Abstract variation generator service implementation.


### PR DESCRIPTION
Removed "Variation" after closing the namespace.